### PR TITLE
fix: safeguard all vignettes and remaining tests against transient AP…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SHARK4R
 Title: Accessing and Validating Marine Environmental Data from 'SHARK' and
     Related Databases
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: c(
     person("Markus", "Lindh", role = "aut",
            comment = c("Swedish Meteorological and Hydrological Institute", ORCID = "0000-0002-7120-4145")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# SHARK4R 1.1.1
+
+## CRAN compliance
+
+* All vignettes that call external APIs now use a hidden availability check followed by `try()`-protected execution chunks, so transient server errors (502, 503, 500) never cause vignette rebuild failures. The user-facing code shown on pkgdown remains clean and uncluttered.
+* Added `skip_if_offline()` and `skip_if_resource_unavailable()` guards to previously unprotected tests for deprecated WoRMS wrappers (`match_wormstaxa`, `update_worms_taxonomy`) and the empty/NA input edge case (`match_worms_taxa(c("", NA))`).
+* Added `skip_on_cran()` to deprecated WoRMS wrapper tests, since the base-URL availability check can pass while individual API endpoints return server errors.
+* Added `skip_if_offline()` to the `"wrong url fails"` test in `test-xylookup.R`.
+
 # SHARK4R 1.1.0
 
 ## New features

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -11,7 +11,7 @@ bibentry(
            comment = c(affiliation = "Swedish Meteorological and Hydrological Institute",
                        ORCID = "0000-0002-8283-656X"))),
   year = "2026",
-  note = "R package version 1.1.0",
+  note = "R package version 1.1.1",
   url = "https://CRAN.R-project.org/package=SHARK4R",
-  textVersion = paste("Lindh, M. and Torstensson, A. (2026). SHARK4R: Accessing and Validating Marine Environmental Data from 'SHARK' and Related Databases. R package version 1.1.0. https://CRAN.R-project.org/package=SHARK4R")
+  textVersion = paste("Lindh, M. and Torstensson, A. (2026). SHARK4R: Accessing and Validating Marine Environmental Data from 'SHARK' and Related Databases. R package version 1.1.1. https://CRAN.R-project.org/package=SHARK4R")
 )

--- a/tests/testthat/test-worms_api_functions.R
+++ b/tests/testthat/test-worms_api_functions.R
@@ -175,6 +175,8 @@ test_that("deprecated update_worms_taxonomy with deprecated argument works as ex
 })
 
 test_that("match_worms_taxa handles empty or NA taxa gracefully", {
+  skip_if_offline()
+  skip_if_resource_unavailable(url)
   res_empty <- match_worms_taxa(c("", NA))
   expect_s3_class(res_empty, "data.frame")
   expect_true("" %in% res_empty$name)

--- a/tests/testthat/test-xylookup.R
+++ b/tests/testthat/test-xylookup.R
@@ -91,6 +91,7 @@ test_that("lookup_xy no data works", {
 })
 
 test_that("wrong url fails", {
+  skip_if_offline()
   options(obistools_xylookup_url = "https://api.obis.org/thisdoesnotexist")
   on.exit(options(obistools_xylookup_url = NULL))
   data <- test_data(x=0,y=0)

--- a/vignettes/quality_control.Rmd
+++ b/vignettes/quality_control.Rmd
@@ -55,13 +55,24 @@ library(SHARK4R)
 
 You can fetch SHARK data using the same filtering options as the SHARK web interface. Explore available options with:
 
-```{r, eval=shark_available}
+```{r, include=FALSE, eval=shark_available}
+shark_options <- try(get_shark_options(), silent = TRUE)
+if (inherits(shark_options, "try-error")) shark_available <- FALSE
+```
+
+```{r, eval=FALSE}
 shark_options <- get_shark_options()
 ```
 
 Filter datasets containing "Chlorophyll":
 
-```{r, eval=shark_available}
+```{r, include=FALSE, eval=shark_available}
+chlorophyll_datasets <- shark_options$datasets[grepl("Chlorophyll",
+                                                     shark_options$datasets)]
+selected_dataset <- chlorophyll_datasets[1]
+```
+
+```{r, eval=FALSE}
 # Filter names using grepl
 chlorophyll_datasets <- shark_options$datasets[grepl("Chlorophyll",
                                                      shark_options$datasets)]
@@ -73,14 +84,31 @@ selected_dataset <- chlorophyll_datasets[1]
 print(selected_dataset)
 ```
 
+```{r, echo=FALSE, eval=shark_available}
+print(selected_dataset)
+```
+
 Download the selected dataset as a data frame:
 
-```{r, eval=shark_available}
+```{r, include=FALSE, eval=shark_available}
+chlorophyll_data <- try(
+  get_shark_datasets(selected_dataset, save_dir = tempdir(),
+                     return_df = TRUE, verbose = FALSE),
+  silent = TRUE
+)
+if (inherits(chlorophyll_data, "try-error")) shark_available <- FALSE
+```
+
+```{r, eval=FALSE}
 chlorophyll_data <- get_shark_datasets(selected_dataset,
                                        save_dir = tempdir(),
                                        return_df = TRUE,
                                        verbose = FALSE)
 
+print(chlorophyll_data)
+```
+
+```{r, echo=FALSE, eval=shark_available}
 print(chlorophyll_data)
 ```
 
@@ -95,8 +123,19 @@ Validate mandatory fields:
 - **Global fields**: `check_datatype()`
 - **Datatype-specific fields**: `check_fields()` with optional `field_definitions`
 
-```{r, eval=shark_available}
+```{r, include=FALSE, eval=shark_available}
+check_fields_result <- try(
+  check_fields(data = chlorophyll_data, datatype = "Chlorophyll"),
+  silent = TRUE
+)
+```
+
+```{r, eval=FALSE}
 check_fields(data = chlorophyll_data, datatype = "Chlorophyll")
+```
+
+```{r, echo=FALSE, eval=shark_available && !inherits(check_fields_result, "try-error")}
+check_fields_result
 ```
 
 ---
@@ -105,7 +144,16 @@ check_fields(data = chlorophyll_data, datatype = "Chlorophyll")
 
 Ensure metadata codes follow SHARK conventions:
 
-```{r, eval=shark_available}
+```{r, include=FALSE, eval=shark_available}
+check_codes_result1 <- try(check_codes(chlorophyll_data), silent = TRUE)
+check_codes_result2 <- try(
+  check_codes(data = chlorophyll_data, field = "platform_code",
+              code_type = "SHIPC", match_column = "Code"),
+  silent = TRUE
+)
+```
+
+```{r, eval=FALSE}
 # Validate project codes
 check_codes(chlorophyll_data)
 
@@ -114,6 +162,14 @@ check_codes(data = chlorophyll_data,
             field = "platform_code",
             code_type = "SHIPC",
             match_column = "Code")
+```
+
+```{r, echo=FALSE, eval=shark_available && !inherits(check_codes_result1, "try-error")}
+check_codes_result1
+```
+
+```{r, echo=FALSE, eval=shark_available && !inherits(check_codes_result2, "try-error")}
+check_codes_result2
 ```
 
 ---
@@ -132,8 +188,17 @@ message("The interactive map is omitted here but appears in the online tutorial.
 
 ### Identify Points on Land
 
-```{r, eval=shark_available && obis_available}
+```{r, include=FALSE, eval=shark_available && obis_available}
+n_rows_on_land <- try(check_onland(chlorophyll_data), silent = TRUE)
+onland_ok <- !inherits(n_rows_on_land, "try-error")
+```
+
+```{r, eval=FALSE}
 n_rows_on_land <- check_onland(chlorophyll_data)
+nrow(n_rows_on_land)
+```
+
+```{r, echo=FALSE, eval=shark_available && obis_available && onland_ok}
 nrow(n_rows_on_land)
 ```
 
@@ -148,9 +213,23 @@ Optional geospatial QC functions:
 
 Verify plausibility and consistency of depth values:
 
-```{r, eval=shark_available && obis_available}
+```{r, include=FALSE, eval=shark_available && obis_available}
+depth_result1 <- try(check_depth(data = chlorophyll_data), silent = TRUE)
+depth_result2 <- try(
+  check_depth(data = chlorophyll_data, "water_depth_m"),
+  silent = TRUE
+)
+depth_ok <- !inherits(depth_result1, "try-error")
+```
+
+```{r, eval=FALSE}
 check_depth(data = chlorophyll_data) # default columns: min/max depth
 check_depth(data = chlorophyll_data, "water_depth_m")
+```
+
+```{r, echo=FALSE, eval=shark_available && obis_available && depth_ok}
+depth_result1
+depth_result2
 ```
 
 Checks performed:
@@ -165,7 +244,16 @@ Checks performed:
 
 Retrieve reference statistics for your datatype:
 
-```{r, eval=shark_available}
+```{r, include=FALSE, eval=shark_available}
+shark_statistics <- try(
+  get_shark_statistics(datatype = "Chlorophyll", fromYear = 2020,
+                       toYear = 2024, verbose = FALSE),
+  silent = TRUE
+)
+stats_ok <- !inherits(shark_statistics, "try-error")
+```
+
+```{r, eval=FALSE}
 shark_statistics <- get_shark_statistics(datatype = "Chlorophyll",
                                          fromYear = 2020,
                                          toYear = 2024,
@@ -174,9 +262,21 @@ shark_statistics <- get_shark_statistics(datatype = "Chlorophyll",
 print(shark_statistics)
 ```
 
+```{r, echo=FALSE, eval=shark_available && stats_ok}
+print(shark_statistics)
+```
+
 Detect extreme values using thresholds (e.g., 99th percentile):
 
-```{r, eval=shark_available}
+```{r, eval=FALSE}
+check_outliers(data = chlorophyll_data,
+               parameter = "Chlorophyll-a",
+               datatype = "Chlorophyll",
+               threshold_col = "P99",
+               thresholds = shark_statistics)
+```
+
+```{r, echo=FALSE, eval=shark_available && stats_ok}
 check_outliers(data = chlorophyll_data,
                parameter = "Chlorophyll-a",
                datatype = "Chlorophyll",
@@ -186,7 +286,7 @@ check_outliers(data = chlorophyll_data,
 
 Visualize anomalies:
 
-```{r, eval=shark_available && Sys.getenv("NOT_CRAN", unset = "FALSE") == "TRUE"}
+```{r, eval=shark_available && stats_ok && Sys.getenv("NOT_CRAN", unset = "FALSE") == "TRUE"}
 # Scatterplot with horizontal line at 99th percentile
 scatterplot(chlorophyll_data,
             hline = shark_statistics$P99)
@@ -202,7 +302,11 @@ message("The interactive plot is omitted here but appears in the online tutorial
 
 Use `check_parameter_rules()` to flag measurements that violate parameter-specific or row-wise logical rules.
 
-```{r, eval=shark_available}
+```{r, eval=FALSE}
+check_parameter_rules(data = chlorophyll_data)
+```
+
+```{r, echo=FALSE, eval=shark_available}
 check_parameter_rules(data = chlorophyll_data)
 ```
 
@@ -217,7 +321,12 @@ check_parameter_rules(data = chlorophyll_data)
 
 Verify station names against the official SHARK registry:
 
-```{r, eval=shark_available}
+```{r, eval=FALSE}
+station_match <- match_station(chlorophyll_data$station_name)
+head(station_match)
+```
+
+```{r, echo=FALSE, eval=shark_available}
 station_match <- match_station(chlorophyll_data$station_name)
 head(station_match)
 ```
@@ -235,7 +344,11 @@ message("The interactive map is omitted here but appears in the online tutorial.
 
 To check if stations are nominal (comparing unique coordinates per station):
 
-```{r, eval=shark_available}
+```{r, eval=FALSE}
+check_nominal_station(data = chlorophyll_data)
+```
+
+```{r, echo=FALSE, eval=shark_available}
 check_nominal_station(data = chlorophyll_data)
 ```
 

--- a/vignettes/retrieve_hab_data.Rmd
+++ b/vignettes/retrieve_hab_data.Rmd
@@ -46,7 +46,12 @@ library(SHARK4R)
 
 The complete HAB list, including scientific names and AphiaIDs, can be downloaded from the [IOC-UNESCO Taxonomic Reference List of Harmful Microalgae](https://www.marinespecies.org/hab/). The output fields are customizable through function parameters—for example, setting `classification = FALSE` excludes higher taxonomic information from the results.
 
-```{r, eval=hab_available}
+```{r, include=FALSE, eval=hab_available}
+hab_list <- try(get_hab_list(), silent = TRUE)
+if (inherits(hab_list, "try-error")) hab_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Retrieve complete HAB list
 hab_list <- get_hab_list()
 
@@ -54,9 +59,21 @@ hab_list <- get_hab_list()
 print(hab_list)
 ```
 
+```{r, echo=FALSE, eval=hab_available}
+print(hab_list)
+```
+
 A separate list of harmful non-toxic species is also available (Zingone & Escalera, 2025). This compilation focuses on taxa for which no toxin production is known, yet which have been linked to negative impacts on marine organisms, including mortality and ecosystem disturbance. The list is designed to be used alongside the IOC-UNESCO Taxonomic Reference List of Harmful Microalgae and is mutually exclusive with it. As a result, any species known to produce toxins is omitted, even when reported harmful effects are attributed to non-toxic processes such as oxygen depletion.
 
-```{r, eval=hab_available}
+```{r, include=FALSE, eval=hab_available}
+hab_non_toxic_list <- try(
+  get_hab_list(harmful_non_toxic_only = TRUE, verbose = FALSE),
+  silent = TRUE
+)
+if (inherits(hab_non_toxic_list, "try-error")) hab_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Retrieve complete Harmful non-toxic list
 hab_non_toxic_list <- get_hab_list(harmful_non_toxic_only = TRUE,
                                    verbose = FALSE)
@@ -65,15 +82,28 @@ hab_non_toxic_list <- get_hab_list(harmful_non_toxic_only = TRUE,
 print(hab_non_toxic_list)
 ```
 
+```{r, echo=FALSE, eval=hab_available}
+print(hab_non_toxic_list)
+```
+
 ## Retrieve HAB Toxins From IOC Toxins Database
 
 The complete Toxin list can be downloaded from the [IOC-UNESCO Toxins database](https://toxins.hais.ioc-unesco.org/) using the `get_toxin_list()` function.
 
-```{r, eval=toxin_available}
+```{r, include=FALSE, eval=toxin_available}
+toxin_list <- try(get_toxin_list(), silent = TRUE)
+if (inherits(toxin_list, "try-error")) toxin_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Retrieve complete toxin list
 toxin_list <- get_toxin_list()
 
 # Print result
+print(toxin_list)
+```
+
+```{r, echo=FALSE, eval=toxin_available}
 print(toxin_list)
 ```
 

--- a/vignettes/retrieve_nordic_microalgae_data.Rmd
+++ b/vignettes/retrieve_nordic_microalgae_data.Rmd
@@ -39,11 +39,20 @@ library(SHARK4R)
 
 A complete Nordic Microalgae taxa list can be retrieved through the API.
 
-```{r, eval=nua_available}
+```{r, include=FALSE, eval=nua_available}
+taxa <- try(get_nua_taxa(unparsed = FALSE), silent = TRUE)
+if (inherits(taxa, "try-error")) nua_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Get taxa information
 taxa <- get_nua_taxa(unparsed = FALSE)
 
 # Print data
+print(taxa)
+```
+
+```{r, echo=FALSE, eval=nua_available}
 print(taxa)
 ```
 
@@ -53,7 +62,16 @@ The full taxonomic information can be accessed as an unparsed list by enabling t
 
 Each taxon sheet on Nordic Microalgae contains facts, such as links to external webpages (e.g. AlgaeBase, WoRMS and Dyntaxa). These links can be retrieved through the API.
 
-```{r, eval=nua_available}
+```{r, include=FALSE, eval=nua_available}
+slugs <- sample(taxa$slug, size = 10)
+external_links <- try(
+  get_nua_external_links(slugs, verbose = FALSE, unparsed = FALSE),
+  silent = TRUE
+)
+if (inherits(external_links, "try-error")) nua_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Randomly select 10 taxa from shark_taxon$scientific_name
 slugs <- sample(taxa$slug, size = 10)
 
@@ -66,13 +84,26 @@ external_links <- get_nua_external_links(slugs,
 print(external_links)
 ```
 
+```{r, echo=FALSE, eval=nua_available}
+print(external_links)
+```
+
 The full list of facts can be accessed as an unparsed list by setting the `unparsed` parameter to `TRUE`.
 
 ## Get Nordic Microalgae Harmfulness Information
 
 Taxa listed in the [IOC-UNESCO Taxonomic Reference List of Harmful Microalgae](https://www.marinespecies.org/hab/) contain information about harmfulness. This information can be retrieved through the API.
 
-```{r, eval=nua_available}
+```{r, include=FALSE, eval=nua_available}
+harmfulness <- try(
+  get_nua_harmfulness(c("dinophysis-acuta", "alexandrium-ostenfeldii"),
+                      verbose = FALSE),
+  silent = TRUE
+)
+if (inherits(harmfulness, "try-error")) nua_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Get external links
 harmfulness <- get_nua_harmfulness(c("dinophysis-acuta",
                                      "alexandrium-ostenfeldii"),
@@ -82,15 +113,28 @@ harmfulness <- get_nua_harmfulness(c("dinophysis-acuta",
 print(harmfulness)
 ```
 
+```{r, echo=FALSE, eval=nua_available}
+print(harmfulness)
+```
+
 ## Get Nordic Microalgae Media Links
 
 Links to all images present on Nordic Microalgae can be retrieved through the API. The images are available in four sizes: original (o), small (s), medium (m), and large (l).
 
-```{r, eval=nua_available}
+```{r, include=FALSE, eval=nua_available}
+media <- try(get_nua_media_links(unparsed = FALSE), silent = TRUE)
+if (inherits(media, "try-error")) nua_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Get all media links
 media <- get_nua_media_links(unparsed = FALSE)
 
 # Print list
+print(media)
+```
+
+```{r, echo=FALSE, eval=nua_available}
 print(media)
 ```
 
@@ -100,7 +144,12 @@ Complete media information can be retrieved as an unparsed list by setting the `
 
 Detailed metadata for all media items on Nordic Microalgae can be retrieved through the API. This includes information such as location, sampling date, geographic coordinates, imaging technique, and contributor details.
 
-```{r, eval=nua_available}
+```{r, include=FALSE, eval=nua_available}
+media_metadata <- try(get_nua_media_metadata(unparsed = FALSE), silent = TRUE)
+if (inherits(media_metadata, "try-error")) nua_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Get all media metadata
 media_metadata <- get_nua_media_metadata(unparsed = FALSE)
 
@@ -108,11 +157,20 @@ media_metadata <- get_nua_media_metadata(unparsed = FALSE)
 print(media_metadata)
 ```
 
+```{r, echo=FALSE, eval=nua_available}
+print(media_metadata)
+```
+
 ## Get Nordic Microalgae Image Labeling Links
 
 Nordic Microalgae hosts images from automated imaging instruments (e.g., IFCB) used for image labeling. Links to these images can be retrieved through the API, similar to `get_nua_media_links()`.
 
-```{r, eval=nua_available}
+```{r, include=FALSE, eval=nua_available}
+il_links <- try(get_nua_image_labeling_links(unparsed = FALSE), silent = TRUE)
+if (inherits(il_links, "try-error")) nua_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Get all image labeling media links
 il_links <- get_nua_image_labeling_links(unparsed = FALSE)
 
@@ -120,11 +178,23 @@ il_links <- get_nua_image_labeling_links(unparsed = FALSE)
 print(il_links)
 ```
 
+```{r, echo=FALSE, eval=nua_available}
+print(il_links)
+```
+
 ## Get Nordic Microalgae Image Labeling Metadata
 
 Detailed metadata for automated imaging images can be retrieved through the API. This includes information about the imaging instrument, training dataset, location, and taxonomic details.
 
-```{r, eval=nua_available}
+```{r, include=FALSE, eval=nua_available}
+il_metadata <- try(
+  get_nua_image_labeling_metadata(unparsed = FALSE),
+  silent = TRUE
+)
+if (inherits(il_metadata, "try-error")) nua_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Get all image labeling metadata
 il_metadata <- get_nua_image_labeling_metadata(unparsed = FALSE)
 
@@ -132,11 +202,22 @@ il_metadata <- get_nua_image_labeling_metadata(unparsed = FALSE)
 print(il_metadata)
 ```
 
+```{r, echo=FALSE, eval=nua_available}
+print(il_metadata)
+```
+
 ## Get NOMP and EG Phyto Biovolume lists
 
 To standardize phytoplankton monitoring efforts in the Baltic Sea, Skagerrak, and the North Sea, various lists containing size class information for each taxon have been established. These lists can be retrieved directly in R using `SHARK4R`:
 
-```{r, eval=nua_available}
+```{r, include=FALSE, eval=nua_available}
+peg_list <- try(get_peg_list(), silent = TRUE)
+nomp_list <- try(get_nomp_list(), silent = TRUE)
+peg_ok <- !inherits(peg_list, "try-error")
+nomp_ok <- !inherits(nomp_list, "try-error")
+```
+
+```{r, eval=FALSE}
 # Get EG Phyto Biovolume list
 peg_list <- get_peg_list()
 
@@ -147,6 +228,14 @@ print(peg_list)
 nomp_list <- get_nomp_list()
 
 # Print list
+print(nomp_list)
+```
+
+```{r, echo=FALSE, eval=nua_available && peg_ok}
+print(peg_list)
+```
+
+```{r, echo=FALSE, eval=nua_available && nomp_ok}
 print(nomp_list)
 ```
 

--- a/vignettes/retrieve_shark_data.Rmd
+++ b/vignettes/retrieve_shark_data.Rmd
@@ -37,7 +37,17 @@ library(SHARK4R)
 
 Data can be retrieved with the same filtering options available in [SHARK](https://shark.smhi.se/en/). To see the available filtering options, please refer to `get_shark_options()` and the information below.
 
-```{r, eval=shark_available}
+```{r, include=FALSE, eval=shark_available}
+shark_data <- try(
+  get_shark_data(fromYear = 2019, toYear = 2020,
+                 months = c(4, 5, 6), dataTypes = "Chlorophyll",
+                 verbose = FALSE),
+  silent = TRUE
+)
+if (inherits(shark_data, "try-error")) shark_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Retrieve chlorophyll data for April to June from 2019 to 2020
 shark_data <- get_shark_data(fromYear = 2019,
                              toYear = 2020,
@@ -49,11 +59,20 @@ shark_data <- get_shark_data(fromYear = 2019,
 print(shark_data)
 ```
 
+```{r, echo=FALSE, eval=shark_available}
+print(shark_data)
+```
+
 ## Get SHARK API Options
 
 Filtering options, including data types, dataset names, stations, taxa, and more, can be retrieved using the `get_shark_options()` function.
 
-```{r, eval=shark_available}
+```{r, include=FALSE, eval=shark_available}
+shark_options <- try(get_shark_options(), silent = TRUE)
+if (inherits(shark_options, "try-error")) shark_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Retrieve available search options
 shark_options <- get_shark_options()
 
@@ -69,13 +88,30 @@ datasetNames <- shark_options$datasets
 head(datasetNames) # Print first few dataset names
 ```
 
+```{r, echo=FALSE, eval=shark_available}
+names(shark_options)
+dataTypes <- shark_options$dataTypes
+print(dataTypes)
+datasetNames <- shark_options$datasets
+head(datasetNames)
+```
+
 ## Retrieve Datasets (Zip-archives)
 
 In addition to accessing data in tabular form, you can also download complete datasets packaged as zip archives. This is useful if you want to store complete datasets locally for further analysis.
 
 To explore all available dataset names, use the `get_shark_options()`. Once you know which datasets you need, you can pass their names (or partial names) to the `get_shark_datasets()` function.
 
-```{r, eval=shark_available}
+```{r, include=FALSE, eval=shark_available}
+dataset_name <- datasetNames[1:2]
+shark_data_zip <- try(
+  get_shark_datasets(dataset_name, save_dir = tempdir(), verbose = FALSE),
+  silent = TRUE
+)
+if (inherits(shark_data_zip, "try-error")) shark_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Select a dataset name (e.g., the first two in the list)
 dataset_name <- datasetNames[1:2]
 
@@ -85,6 +121,10 @@ shark_data_zip <- get_shark_datasets(dataset_name,
                                      verbose = FALSE) # Quiet output
 
 # Print the paths to the downloaded files
+print(shark_data_zip)
+```
+
+```{r, echo=FALSE, eval=shark_available}
 print(shark_data_zip)
 ```
 

--- a/vignettes/retrieve_worms_data.Rmd
+++ b/vignettes/retrieve_worms_data.Rmd
@@ -56,7 +56,16 @@ suppressPackageStartupMessages({
 
 Phytoplankton data, including scientific names and AphiaIDs, are downloaded from SHARK. To see more download options, please visit the [Retrieve Data From SHARK](https://sharksmhi.github.io/SHARK4R/articles/retrieve_shark_data.html) tutorial.
 
-```{r, eval=apis_available}
+```{r, include=FALSE, eval=apis_available}
+shark_data <- try(
+  get_shark_data(fromYear = 2015, toYear = 2015, months = 4,
+                 dataTypes = "Phytoplankton", verbose = FALSE),
+  silent = TRUE
+)
+if (inherits(shark_data, "try-error")) apis_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Retrieve all phytoplankton data from April 2015
 shark_data <- get_shark_data(fromYear = 2015,
                              toYear = 2015,
@@ -69,7 +78,20 @@ shark_data <- get_shark_data(fromYear = 2015,
 
 Taxon names can be matched with the WoRMS API to retrieve Aphia IDs and corresponding taxonomic information. The `match_worms_taxa()` function incorporates retry logic to handle temporary failures, ensuring that all names are processed successfully.
 
-```{r, eval=apis_available}
+```{r, include=FALSE, eval=apis_available}
+no_aphia_id <- shark_data %>% filter(is.na(aphia_id))
+taxa_names <- sample(unique(no_aphia_id$scientific_name),
+                     size = 10, replace = TRUE)
+worms_records <- try(
+  match_worms_taxa(unique(taxa_names), fuzzy = TRUE,
+                   best_match_only = TRUE, marine_only = TRUE,
+                   verbose = FALSE),
+  silent = TRUE
+)
+if (inherits(worms_records, "try-error")) apis_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Find taxa without Aphia ID
 no_aphia_id <- shark_data %>%
   filter(is.na(aphia_id))
@@ -90,11 +112,25 @@ worms_records <- match_worms_taxa(unique(taxa_names),
 print(worms_records)
 ```
 
+```{r, echo=FALSE, eval=apis_available}
+print(worms_records)
+```
+
 ### Get WoRMS records from AphiaID
 
 Taxonomic records can also be retrieved using Aphia IDs, employing the same retry and error-handling logic as the `match_worms_taxa()` function.
 
-```{r, eval=apis_available}
+```{r, include=FALSE, eval=apis_available}
+aphia_ids <- sample(unique(shark_data$aphia_id), size = 10)
+aphia_ids <- aphia_ids[!is.na(aphia_ids)]
+worms_records <- try(
+  get_worms_records(aphia_ids, verbose = FALSE),
+  silent = TRUE
+)
+if (inherits(worms_records, "try-error")) apis_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Randomly select ten Aphia IDs
 aphia_ids <- sample(unique(shark_data$aphia_id),
                     size = 10)
@@ -110,11 +146,23 @@ worms_records <- get_worms_records(aphia_ids,
 print(worms_records)
 ```
 
+```{r, echo=FALSE, eval=apis_available}
+print(worms_records)
+```
+
 ### Get WoRMS Taxonomy
 
 SHARK sources taxonomic information from [Dyntaxa](https://artfakta.se/), which is reflected in columns starting with `taxon_xxxxx`. Equivalent columns based on WoRMS can be retrieved using the `add_worms_taxonomy()` function.
 
-```{r, eval=apis_available}
+```{r, include=FALSE, eval=apis_available}
+worms_taxonomy <- try(
+  add_worms_taxonomy(aphia_ids, verbose = FALSE),
+  silent = TRUE
+)
+if (inherits(worms_taxonomy, "try-error")) apis_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Retrieve taxonomic table
 worms_taxonomy <- add_worms_taxonomy(aphia_ids,
                                      verbose = FALSE)
@@ -127,11 +175,26 @@ shark_data_with_worms <- shark_data %>%
   left_join(worms_taxonomy, by = "aphia_id")
 ```
 
+```{r, echo=FALSE, eval=apis_available}
+print(worms_taxonomy)
+shark_data_with_worms <- shark_data %>%
+  left_join(worms_taxonomy, by = "aphia_id")
+```
+
 ### Retrieve WoRMS Taxonomic Hierarchies
 
 To explore the full hierarchical taxonomy records of your Aphia IDs, you can use the `get_worms_taxonomy_tree()` function. This function retrieves records for the entire taxonomic tree from WoRMS, including parent-child relationships, and can optionally fetch all descendants (e.g. species) under a genus or known synonyms.
 
-```{r, eval=apis_available}
+```{r, include=FALSE, eval=apis_available}
+worms_tree <- try(
+  get_worms_taxonomy_tree(aphia_ids[1], add_descendants = FALSE,
+                          add_synonyms = FALSE, verbose = FALSE),
+  silent = TRUE
+)
+if (inherits(worms_tree, "try-error")) apis_available <- FALSE
+```
+
+```{r, eval=FALSE}
 # Retrieve taxonomic tree
 worms_tree <- get_worms_taxonomy_tree(
   aphia_ids[1],                # use first id only in this example
@@ -144,11 +207,39 @@ worms_tree <- get_worms_taxonomy_tree(
 print(worms_tree)
 ```
 
+```{r, echo=FALSE, eval=apis_available}
+print(worms_tree)
+```
+
 ### Assign Phytoplankton Groups
 
 Phytoplankton data are often categorized into major groups such as Dinoflagellates, Diatoms, Cyanobacteria, and Others. This grouping can be achieved by referencing information from WoRMS and assigning taxa to these groups based on their taxonomic classification, as demonstrated in the example below.
 
-```{r, eval=apis_available}
+```{r, include=FALSE, eval=apis_available}
+nat_stations <- shark_data %>%
+  filter(station_name %in% c("BY5 BORNHOLMSDJ"))
+sample <- sample(unique(nat_stations$shark_sample_id_md5), 1)
+shark_data_subset <- shark_data %>%
+  filter(shark_sample_id_md5 == sample)
+plankton_groups <- try(
+  assign_phytoplankton_group(
+    scientific_names = shark_data_subset$scientific_name,
+    aphia_ids = shark_data_subset$aphia_id,
+    verbose = FALSE),
+  silent = TRUE
+)
+if (inherits(plankton_groups, "try-error")) {
+  apis_available <- FALSE
+} else {
+  plankton_group_sum <- shark_data_subset %>%
+    mutate(plankton_group = plankton_groups$plankton_group) %>%
+    filter(parameter == "Abundance") %>%
+    group_by(plankton_group) %>%
+    summarise(sum_plankton_groups = sum(value, na.rm = TRUE))
+}
+```
+
+```{r, eval=FALSE}
 # Subset data from one national monitoring station
 nat_stations <- shark_data %>%
   filter(station_name %in% c("BY5 BORNHOLMSDJ"))
@@ -191,11 +282,57 @@ ggplot(plankton_group_sum,
   theme(plot.background = element_rect(fill = "white", color = NA))
 ```
 
+```{r, echo=FALSE, eval=apis_available}
+distinct(plankton_groups)
+
+ggplot(plankton_group_sum,
+       aes(x = "", y = sum_plankton_groups, fill = plankton_group)) +
+  geom_col(width = 1) +
+  coord_polar(theta = "y") +
+  labs(
+    title = "Phytoplankton Groups",
+    subtitle = paste(unique(shark_data_subset$station_name),
+                     unique(shark_data_subset$sample_date)),
+    fill = "Plankton Group"
+  ) +
+  theme_void() +
+  theme(plot.background = element_rect(fill = "white", color = NA))
+```
+
 #### Assign Custom Phytoplankton Groups
 
 You can add custom plankton groups by using the `custom_groups` parameter, allowing flexibility to categorize plankton based on specific taxonomic criteria. Please note that the order of the list matters: taxa are assigned to the last matching group. For example: Mesodinium rubrum will be excluded from the Ciliates group because it appears after Ciliates in the list in the example below.
 
-```{r, eval=apis_available}
+```{r, include=FALSE, eval=apis_available}
+custom_groups <- list(
+  "Cryptophytes" = list(class = "Cryptophyceae"),
+  "Green Algae" = list(class = c("Trebouxiophyceae",
+                                 "Chlorophyceae",
+                                 "Pyramimonadophyceae"),
+                       phylum = "Chlorophyta"),
+  "Ciliates" = list(phylum = "Ciliophora"),
+  "Mesodinium rubrum" = list(scientific_name = "Mesodinium rubrum"),
+  "Dinophysis" = list(genus = "Dinophysis")
+)
+plankton_groups <- try(
+  assign_phytoplankton_group(
+    scientific_names = shark_data_subset$scientific_name,
+    custom_groups = custom_groups,
+    verbose = FALSE),
+  silent = TRUE
+)
+if (inherits(plankton_groups, "try-error")) {
+  apis_available <- FALSE
+} else {
+  plankton_custom_group_sum <- shark_data_subset %>%
+    mutate(plankton_group = plankton_groups$plankton_group) %>%
+    filter(parameter == "Abundance") %>%
+    group_by(plankton_group) %>%
+    summarise(sum_plankton_groups = sum(value, na.rm = TRUE))
+}
+```
+
+```{r, eval=FALSE}
 # Define custom plankton groups using a named list
 custom_groups <- list(
   "Cryptophytes" = list(class = "Cryptophyceae"),
@@ -222,6 +359,21 @@ plankton_custom_group_sum <- shark_data_subset %>%
   summarise(sum_plankton_groups = sum(value, na.rm = TRUE))
 
 # Plot a new pie chart, including the custom groups
+ggplot(plankton_custom_group_sum,
+       aes(x = "", y = sum_plankton_groups, fill = plankton_group)) +
+  geom_col(width = 1) +
+  coord_polar(theta = "y") +
+  labs(
+    title = "Phytoplankton Custom Groups",
+    subtitle = paste(unique(shark_data_subset$station_name),
+                     unique(shark_data_subset$sample_date)),
+    fill = "Plankton Group"
+  ) +
+  theme_void() +
+  theme(plot.background = element_rect(fill = "white", color = NA))
+```
+
+```{r, echo=FALSE, eval=apis_available}
 ggplot(plankton_custom_group_sum,
        aes(x = "", y = sum_plankton_groups, fill = plankton_group)) +
   geom_col(width = 1) +


### PR DESCRIPTION
…I errors

Vignettes now use a triple-chunk pattern: a hidden chunk executes API calls wrapped in try(), a visible chunk (eval=FALSE) shows clean user-facing code, and a hidden output chunk renders results on success. This prevents vignette rebuild failures from transient 502/503/500 errors while keeping pkgdown articles clean.

Added skip_if_offline/skip_if_resource_unavailable/skip_on_cran guards to four previously unprotected test blocks: deprecated WoRMS wrappers, empty/NA input edge case, and wrong-URL xylookup test.